### PR TITLE
The overrides exporter is integrated in cortex since v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [CHANGE] Updated readme to use this repo with tanka
+* [CHANGE] Use integrated cortex overrides exporter
 * [ENHANCEMENT] How to rename buckets in AWS and Azure for `not healthy index found` playbook. #5
 
 ## 1.11.0 / 2021-12-30

--- a/cortex/images.libsonnet
+++ b/cortex/images.libsonnet
@@ -19,7 +19,7 @@
     store_gateway: self.cortex,
     query_scheduler: self.cortex,
 
-    cortex_tools: 'grafana/cortex-tools:v0.4.0',
+    overrides_exporter: self.cortex,
     query_tee: 'quay.io/cortexproject/query-tee:v1.11.0',
     testExporter: 'cortexproject/test-exporter:v1.11.0',
   },

--- a/cortex/overrides-exporter.libsonnet
+++ b/cortex/overrides-exporter.libsonnet
@@ -1,56 +1,23 @@
-// this enables overrides exporter, which will expose the configured
-// overrides and presets (if configured). Those metrics can be potentially
-// high cardinality.
+// this enables overrides exporter, which will expose the configured overrides.
 {
   local name = 'overrides-exporter',
 
-  _config+: {
-    // overrides exporter can also make the configured presets available, this
-    // list references entries within $._config.overrides
-
-    overrides_exporter_presets:: [
-      'extra_small_user',
-      'small_user',
-      'medium_user',
-      'big_user',
-      'super_user',
-      'mega_user',
-    ],
-  },
-
-  local presets_enabled = std.length($._config.overrides_exporter_presets) > 0,
-
-  local configMap = $.core.v1.configMap,
-  overrides_exporter_presets_configmap:
-    if presets_enabled then
-      configMap.new('overrides-presets') +
-      configMap.withData({
-        'overrides-presets.yaml': $.util.manifestYaml(
-          {
-            presets: {
-              [key]: $._config.overrides[key]
-              for key in $._config.overrides_exporter_presets
-            },
-          }
-        ),
-      }),
-
   local containerPort = $.core.v1.containerPort,
-  overrides_exporter_port:: containerPort.newNamed(name='http-metrics', containerPort=9683),
+  overrides_exporter_port:: containerPort.newNamed(name='http-metrics', containerPort=80),
 
   overrides_exporter_args:: {
-    'overrides-file': '/etc/cortex/overrides.yaml',
-  } + if presets_enabled then {
-    'presets-file': '/etc/cortex_presets/overrides-presets.yaml',
-  } else {},
+    target: 'overrides-exporter',
+
+    'runtime-config.file': '/etc/cortex/overrides.yaml',
+  },
 
   local container = $.core.v1.container,
   overrides_exporter_container::
-    container.new(name, $._images.cortex_tools) +
+    container.new(name, $._images.overrides_exporter) +
     container.withPorts([
       $.overrides_exporter_port,
     ]) +
-    container.withArgsMixin([name] + $.util.mapToFlags($.overrides_exporter_args, prefix='--')) +
+    container.withArgsMixin($.util.mapToFlags($.overrides_exporter_args, prefix='--')) +
     $.util.resourcesRequests('0.5', '0.5Gi') +
     $.util.readinessProbe +
     container.mixin.readinessProbe.httpGet.withPort($.overrides_exporter_port.name),
@@ -59,7 +26,6 @@
   overrides_exporter_deployment:
     deployment.new(name, 1, [$.overrides_exporter_container], { name: name }) +
     $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex') +
-    $.util.configVolumeMount('overrides-presets', '/etc/cortex_presets') +
     deployment.mixin.metadata.withLabels({ name: name }),
 
   overrides_exporter_service:


### PR DESCRIPTION
The only caveat is that it doesn't support the presets. But everything else works the same

**What this PR does**: Changes overrides exporter to use cortex image instead of cortex-tools

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
