### PR TITLE
Update s3 endpoint from us-east-1 to aws_region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## master / unreleased
 
-
 * [CHANGE] Updated readme to use this repo with tanka
 * [ENHANCEMENT] How to rename buckets in AWS and Azure for `not healthy index found` playbook. #5
 * [BUGFIX] Updated blocks_storage_s3_endpoint in config.libsonnet to include the correct aws region

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [CHANGE] Updated blocks_storage_s3_endpoint in config.libsonnet to include the correct aws region
 * [CHANGE] Updated readme to use this repo with tanka
 * [ENHANCEMENT] How to rename buckets in AWS and Azure for `not healthy index found` playbook. #5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## master / unreleased
 
-* [CHANGE] Updated blocks_storage_s3_endpoint in config.libsonnet to include the correct aws region
+
 * [CHANGE] Updated readme to use this repo with tanka
 * [ENHANCEMENT] How to rename buckets in AWS and Azure for `not healthy index found` playbook. #5
+* [BUGFIX] Updated blocks_storage_s3_endpoint in config.libsonnet to include the correct aws region
 
 ## 1.11.0 / 2021-12-30
 

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -57,7 +57,7 @@
     storage_engine: 'chunks',  // Available options are 'chunks' or 'blocks'
     blocks_storage_backend: 'gcs',  // Available options are 'gcs', 's3', 'azure'
     blocks_storage_bucket_name: error 'must specify blocks storage bucket name',
-    blocks_storage_s3_endpoint: 's3.dualstack.us-east-1.amazonaws.com',
+    blocks_storage_s3_endpoint: 's3.dualstack.%s.amazonaws.com' % $._config.aws_region,
     blocks_storage_azure_account_name: if $._config.blocks_storage_backend == 'azure' then error 'must specify azure account name' else '',
     blocks_storage_azure_account_key: if $._config.blocks_storage_backend == 'azure' then error 'must specify azure account key' else '',
 


### PR DESCRIPTION
Signed-off-by: Stancu Bogdan Nicolae <bstancu@adobe.com>

**What this PR does**:
Updated blocks_storage_s3_endpoint in config.libsonnet to include the correct aws region. It was hardcoded as us-east-1

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
