### PR TITLE
Use default remote timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [CHANGE] Updated readme to use this repo with tanka
 * [CHANGE] Removed chunks support
 * [CHANGE] Use integrated cortex overrides exporter
+* [CHANGE] Use default remote timeout in distributors
 * [ENHANCEMENT] Added main.jsonnet examples for azure, gcs and s3
 * [ENHANCEMENT] How to rename buckets in AWS and Azure for `not healthy index found` playbook. #5
 * [ENHANCEMENT] Support new metrics cortex_cache_fetched_keys_total and cortex_cache_fetched_keys_total

--- a/cortex/distributor.libsonnet
+++ b/cortex/distributor.libsonnet
@@ -13,7 +13,6 @@
       'validation.reject-old-samples': true,
       'validation.reject-old-samples.max-age': '12h',
       'runtime-config.file': '/etc/cortex/overrides.yaml',
-      'distributor.remote-timeout': '20s',
 
       'distributor.ha-tracker.enable': true,
       'distributor.ha-tracker.enable-for-all-users': true,


### PR DESCRIPTION
Signed-off-by: Friedrich Gonzalez <friedrichg@gmail.com>

**What this PR does**:
Use default remote timeout in distributors (2s) to prevent distributors OOMs

**Checklist**
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

