### PR TITLE
Use policy/v1 PodDisruptionBudget to support k8s 1.25+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master / unreleased
+
+* [CHANGE] Use policy/v1 PodDisruptionBudget to support k8s 1.25+
+
 ## 1.11.1 / 2023-01-13
 
 * [CHANGE] Updated readme to use this repo with tanka

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ test-readme: test-readme/azure test-readme/gcs test-readme/s3
 test-readme/%:
 	rm -rf $@ && \
 	mkdir -p $@ && cd $@ && \
-	tk init --k8s=1.21 && \
+	tk init --k8s=1.23 && \
 	jb install github.com/cortexproject/cortex-jsonnet/cortex@main && \
 	rm -fr ./vendor/cortex && \
 	cp -r ../../cortex ./vendor/ && \

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To generate the YAMLs for deploying Cortex:
 
     ```console
     $ mkdir <name> && cd <name>
-    $ tk init --k8s=1.21 # this includes github.com/jsonnet-libs/k8s-libsonnet/1.21@main
+    $ tk init --k8s=1.23 # this includes github.com/jsonnet-libs/k8s-libsonnet/1.23@main
     $ jb install github.com/cortexproject/cortex-jsonnet/cortex@main
     ```
 

--- a/cortex/ingester.libsonnet
+++ b/cortex/ingester.libsonnet
@@ -1,5 +1,5 @@
 {
-  local podDisruptionBudget = $.policy.v1beta1.podDisruptionBudget,
+  local podDisruptionBudget = $.policy.v1.podDisruptionBudget,
   local pvc = $.core.v1.persistentVolumeClaim,
   local statefulSet = $.apps.v1.statefulSet,
   local volume = $.core.v1.volume,
@@ -90,8 +90,7 @@
   ingester_service_ignored_labels:: [],
 
   newIngesterPdb(pdbName, ingesterName)::
-    podDisruptionBudget.new() +
-    podDisruptionBudget.mixin.metadata.withName(pdbName) +
+    podDisruptionBudget.new(pdbName) +
     podDisruptionBudget.mixin.metadata.withLabels({ name: pdbName }) +
     podDisruptionBudget.mixin.spec.selector.withMatchLabels({ name: ingesterName }) +
     podDisruptionBudget.mixin.spec.withMaxUnavailable(1),

--- a/cortex/store-gateway.libsonnet
+++ b/cortex/store-gateway.libsonnet
@@ -1,6 +1,6 @@
 {
   local container = $.core.v1.container,
-  local podDisruptionBudget = $.policy.v1beta1.podDisruptionBudget,
+  local podDisruptionBudget = $.policy.v1.podDisruptionBudget,
   local pvc = $.core.v1.persistentVolumeClaim,
   local statefulSet = $.apps.v1.statefulSet,
   local volumeMount = $.core.v1.volumeMount,
@@ -69,8 +69,7 @@
     $.util.serviceFor($.store_gateway_statefulset),
 
   store_gateway_pdb:
-    podDisruptionBudget.new() +
-    podDisruptionBudget.mixin.metadata.withName('store-gateway-pdb') +
+    podDisruptionBudget.new('store-gateway-pdb') +
     podDisruptionBudget.mixin.metadata.withLabels({ name: 'store-gateway-pdb' }) +
     podDisruptionBudget.mixin.spec.selector.withMatchLabels({ name: 'store-gateway' }) +
     // To avoid any disruption in the read path we need at least 1 replica of each


### PR DESCRIPTION
Signed-off-by: Friedrich Gonzalez <friedrichg@gmail.com>

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
