### PR TITLE
Enables query-scheduler by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [CHANGE] Enables query-scheduler by default
+
 ## 1.13.2 / 2023-04-29
 
 * [CHANGE] Use policy/v1 PodDisruptionBudget to support k8s 1.25+

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -371,7 +371,7 @@
     alertmanager_enabled: false,
 
     // Enables query-scheduler component, and reconfigures querier and query-frontend to use it.
-    query_scheduler_enabled: false,
+    query_scheduler_enabled: true,
 
     // Enables streaming of chunks from ingesters using blocks.
     // Changing it will not cause new rollout of ingesters, as it gets passed to them via runtime-config.


### PR DESCRIPTION
**What this PR does**: Enables query-scheduler by default

No query-scheduler means no hpa for querier or query-frontend. It's a bad choice

**Checklist**
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
