### PR TITLE
Filter out user label added in cortex_bucket_store_blocks_loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [CHANGE] Use faster disks for compactor
 * [CHANGE] Enables query-scheduler by default
 * [CHANGE] Enables bucket-index by default
+* [BUGFIX] Fix `Blocks currently loaded` in Queries
 
 ## 1.13.2 / 2023-04-29
 

--- a/cortex-mixin/dashboards/queries.libsonnet
+++ b/cortex-mixin/dashboards/queries.libsonnet
@@ -254,7 +254,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       $.row('')
       .addPanel(
         $.panel('Blocks currently loaded') +
-        $.queryPanel('cortex_bucket_store_blocks_loaded{component="store-gateway",%s}' % $.jobMatcher($._config.job_names.store_gateway), '{{%s}}' % $._config.per_instance_label)
+        $.queryPanel('sum(cortex_bucket_store_blocks_loaded{component="store-gateway",%s}) without (user)' % $.jobMatcher($._config.job_names.store_gateway), '{{%s}}' % $._config.per_instance_label)
       )
       .addPanel(
         $.successFailurePanel(


### PR DESCRIPTION

**What this PR does**: Filter out user label added in cortex_bucket_store_blocks_loaded

Related to https://github.com/cortexproject/cortex/pull/4918

**Checklist**
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
