### PR TITLE
Decrease GOMEMLIMIT a bit to avoid running out of memory before trashing

### DIFF
--- a/cortex/compactor.libsonnet
+++ b/cortex/compactor.libsonnet
@@ -53,7 +53,7 @@
 
   compactor_env_map:: {
     GOMAXPROCS: std.toString($._config.cortex_compactor_max_concurrency),
-    GOMEMLIMIT: '6GiB',
+    GOMEMLIMIT: '5GiB',
   },
 
   newCompactorStatefulSet(name, container)::


### PR DESCRIPTION
**What this PR does**: Decrease GOMEMLIMIT a bit to avoid running out of memory before trashing

Continuation to https://github.com/cortexproject/cortex-jsonnet/pull/32