### PR TITLE
Enable query stats on frontend by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 * [CHANGE] Use cortex v1.16.0
+* [ENHANCEMENT] Enable frontend query stats by default
 
 ## 1.15.3 / 2023-11-24
 * [CHANGE] Add default instance max series for ingesters

--- a/cortex/query-frontend.libsonnet
+++ b/cortex/query-frontend.libsonnet
@@ -7,8 +7,11 @@
     {
       target: 'query-frontend',
 
-      // Need log.level=debug so all queries are logged, needed for analyse.py.
+      // Need log.level=debug to see trace id for queries
       'log.level': 'debug',
+
+      // a message with some statistics is logged for every query.
+      'frontend.query-stats-enabled': true,
 
       // Increase HTTP server response write timeout, as we were seeing some
       // queries that return a lot of data timeing out.


### PR DESCRIPTION
**What this PR does**: Enable frontend query stats by default

**Checklist**
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
