### PR TITLE
Enable ruler query stats by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 * [CHANGE] Use cortex v1.16.0
 * [ENHANCEMENT] Enable frontend query stats by default
+* [ENHANCEMENT] Enable ruler query stats by default
 
 ## 1.15.3 / 2023-11-24
 * [CHANGE] Add default instance max series for ingesters

--- a/cortex/ruler.libsonnet
+++ b/cortex/ruler.libsonnet
@@ -32,6 +32,9 @@
       // Do not extend the replication set on unhealthy (or LEAVING) ingester when "unregister on shutdown"
       // is set to false.
       'distributor.extend-writes': $._config.unregister_ingesters_on_shutdown,
+
+      // a message with some statistics is logged for every query.
+      'ruler.query-stats-enabled': true,
     },
 
   ruler_container::


### PR DESCRIPTION
**What this PR does**: Enable ruler query stats by default


**Checklist**
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
