### PR TITLE
Upgrade memcached to 1.6.23 and memcached-exporter to v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master / unreleased
+* [CHANGE] Upgrade memcached to 1.6.23-alpine and memcached-exporter to v0.14.2
 * [CHANGE] Use cortex v1.16.0
 * [ENHANCEMENT] Enable frontend query stats by default
 * [ENHANCEMENT] Enable ruler query stats by default

--- a/cortex/images.libsonnet
+++ b/cortex/images.libsonnet
@@ -1,8 +1,8 @@
 {
   _images+:: {
     // Various third-party images.
-    memcached: 'memcached:1.6.9-alpine',
-    memcachedExporter: 'prom/memcached-exporter:v0.6.0',
+    memcached: 'memcached:1.6.23-alpine',
+    memcachedExporter: 'prom/memcached-exporter:v0.14.2',
 
     // Our services.
     cortex: 'cortexproject/cortex:v1.16.0',


### PR DESCRIPTION
**What this PR does**: Upgrade memcached to 1.6.23 and memcached-exporter to v0.14.2

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
