### PR TITLE
Use ignore-blocks-within

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [CHANGE] Use cortex v1.16.0
 * [ENHANCEMENT] Enable frontend query stats by default
 * [ENHANCEMENT] Enable ruler query stats by default
+* [ENHANCEMENT] Configure `-blocks-storage.bucket-store.ignore-blocks-within` in queriers, rulers and store-gateways
 
 ## 1.15.3 / 2023-11-24
 * [CHANGE] Add default instance max series for ingesters

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -74,8 +74,18 @@
       'store.engine': 'blocks',
     },
 
+    // Ignore blocks in querier, ruler and store-gateways for the last 11h
+    ignore_blocks_within: '11h',
+
+    // No need to look at store for data younger than 12h, as ingesters have all of it.
+    query_store_after: '12h',
+
+    // Ingesters don't have data older than 13h, no need to ask them.
+    query_ingesters_within: '13h',
+
     queryBlocksStorageConfig:: {
       'blocks-storage.bucket-store.sync-dir': '/data/tsdb',
+      'blocks-storage.bucket-store.ignore-blocks-within': $._config.ignore_blocks_within,
       'blocks-storage.bucket-store.ignore-deletion-marks-delay': '1h',
 
       'store-gateway.sharding-enabled': true,
@@ -116,12 +126,8 @@
       // type queries. 32 days to allow for comparision over the last month (31d) and
       // then some.
       'store.max-query-length': '768h',
-
-      // Ingesters don't have data older than 13h, no need to ask them.
-      'querier.query-ingesters-within': '13h',
-
-      // No need to look at store for data younger than 12h, as ingesters have all of it.
-      'querier.query-store-after': '12h',
+      'querier.query-ingesters-within': $._config.query_ingesters_within,
+      'querier.query-store-after': $._config.query_store_after,
     },
 
     // PromQL query engine config (shared between all services running PromQL engine, like the ruler and querier).


### PR DESCRIPTION
**What this PR does**: Use ignore-blocks-within in queriers, ruler and store-gateways


**Checklist**
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
