### PR TITLE
Enable ingester grpc compression to be snappy-block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## master / unreleased
+* [ENHANCEMENT] Configure `-ingester.client.grpc-compression` to be `snappy-block`
+
 ## 1.16.1
 * [CHANGE] Upgrade memcached to 1.6.23-alpine and memcached-exporter to v0.14.2
 * [CHANGE] Use cortex v1.16.1

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -145,6 +145,7 @@
       'distributor.replication-factor': $._config.replication_factor,
       'distributor.shard-by-all-labels': true,
       'distributor.health-check-ingesters': true,
+      'ingester.client.grpc-compression': 'snappy-block',
       'ring.heartbeat-timeout': '10m',
     },
 


### PR DESCRIPTION

**What this PR does**: Reduces 93.6% traffic between ingester and distributor. Causes no additional latency, cpu or memory usage

**Checklist**
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
