### PR TITLE
Update jsonnet-libs to Fri Jul 19 12:51:49 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [CHANGE] Use cortex v1.17.1
 * [CHANGE] Enable shuffle sharding in compactors
 * [CHANGE] Remove chunks support for dashboards
+* [CHANGE] Update jsonnet-libs to Fri Jul 19 12:51:49 2024 #57
 * [ENHANCEMENT] Configure `-ingester.client.grpc-compression` to be `snappy-block`
 * [ENHANCEMENT] Support Grafana 11 in Cortex Service Scaling Dashboard
 

--- a/cortex-mixin/jsonnetfile.lock.json
+++ b/cortex-mixin/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "0d13e5ba1b3a4c29015738c203d92ea39f71ebe2",
-      "sum": "GRf2GvwEU4jhXV+JOonXSZ4wdDv8mnHBPCQ6TUVd+g8="
+      "version": "1d877bb0651ef92176f651d0be473c06e372a8a0",
+      "sum": "udZaafkbKYMGodLqsFhEe+Oy/St2p0edrK7hiMPEey0="
     },
     {
       "source": {
@@ -18,8 +18,8 @@
           "subdir": "mixin-utils"
         }
       },
-      "version": "21b638f4e4922c0b6fde12120ed45d8ef803edc7",
-      "sum": "Je2SxBKu+1WrKEEG60zjSKaY/6TPX8uRz5bsaw0a8oA="
+      "version": "1d877bb0651ef92176f651d0be473c06e372a8a0",
+      "sum": "mzLmCv9n3ldLChVGPfyRJOVKoBw+dfK40vU9792aHIM="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
**What this PR does**:
Updates grafana-builder and mixin-utils to latest version in master branch. This will be helpful in creating Grafana panels that use the timeseriesPanel instead of the deprecated panel.

grafana-builder changes:

- grafana-builder: add support for native/classic stat panel query (grafana/jsonnet-libs#1285)
- More native histograms related utils and renaming (grafana/jsonnet-libs#1270)
- Support recording and switching between naive and classic latency histograms (grafana/jsonnet-libs#1150)
- Basic native histogram utilities (grafana/jsonnet-libs#1164)
- grafana-builder: rename template variable "Data Source" to "Data source" (grafana/jsonnet-libs#1111)
- Mixins: draw graphs at full resolution (grafana/jsonnet-libs#825)
- Allow dashboards to show gRPC codes as labels (grafana/jsonnet-libs#1098)
- Allow configuring sort order for variables (grafana/jsonnet-libs#1014)
- remove unused/wrong step param (grafana/jsonnet-libs#999)
- Show cancelled requests in grey on QPS dashboards. (grafana/jsonnet-libs#988)
- Show cancelled requests in yellow on QPS dashboards. (grafana/jsonnet-libs#986)
- Add timeseriesPanel (grafana/jsonnet-libs#824)
- Allow including "All" for single template var
- Allow datasource's regex to be configured
- grafana-builder: make allValue configurable (grafana/jsonnet-libs#703)
- grafana_builder: add dashboard link func (grafana/jsonnet-libs#683)
- Add 'Data Source' label for the default datasource template variable. (grafana/jsonnet-libs#672)
- enable toolip by default (grafana/jsonnet-libs#665)

mixin-utils changes:

- grafana-builder: add support for native/classic stat panel query (grafana/jsonnet-libs#1285)
- More native histograms related utils and renaming (grafana/jsonnet-libs#1270)
- nativeClassicSumBy: format list of labels nicer (grafana/jsonnet-libs#1204)
- Support recording and switching between naive and classic latency histograms (grafana/jsonnet-libs#1150)
- chore: fix hardcoded range interval (grafana/jsonnet-libs#1190)
- Basic native histogram utilities (grafana/jsonnet-libs#1164)
- utils: allow defining native histogram recording rule (grafana/jsonnet-libs#1156)
- modify withRunbookURL to allow internal annotation (grafana/jsonnet-libs#1139)
- mixin-utils: drop unsupported step target parameter (grafana/jsonnet-libs#1128)
- Mixins: draw graphs at full resolution (grafana/jsonnet-libs#825)
- Align with style conventions (grafana/jsonnet-libs#1038)
- Add a function to remove an alert rule (grafana/jsonnet-libs#812)
- mixin-utils: Parameterize interval for histogramRules (grafana/jsonnet-libs#806)
- refactor(grafana/jsonnet-libsprometheus): shard mixins over multiple configmaps (grafana/jsonnet-libs#497)
- Not all Prometheus rules are alerts. (grafana/jsonnet-libs#490)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
