### PR TITLE
[BUGFIX] Remove deprecated option - max_series_per_query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [CHANGE] Increase CortexProvisioningTooManyWrites alert threshold to 160e3
 * [ENHANCEMENT] Configure `-ingester.client.grpc-compression` to be `snappy-block`
 * [ENHANCEMENT] Support Grafana 11 in Cortex Service Scaling Dashboard
+* [BUGFIX] Remove deprecated option `max_series_per_query`
 
 ## 1.16.1
 * [CHANGE] Upgrade memcached to 1.6.23-alpine and memcached-exporter to v0.14.2

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -236,7 +236,6 @@
       'ingester.max-series-per-metric': $._config.limits.max_series_per_metric,
       'ingester.max-global-series-per-user': $._config.limits.max_global_series_per_user,
       'ingester.max-global-series-per-metric': $._config.limits.max_global_series_per_metric,
-      'ingester.max-series-per-query': $._config.limits.max_series_per_query,
     },
     rulerLimitsConfig: {
       'ruler.max-rules-per-rule-group': $._config.limits.ruler_max_rules_per_rule_group,
@@ -259,8 +258,6 @@
         max_global_series_per_user: 150000,
         max_global_series_per_metric: 20000,
 
-        max_series_per_query: 100000,
-
         ingestion_rate: 10000,
         ingestion_burst_size: 200000,
 
@@ -281,8 +278,6 @@
         max_global_series_per_user: 300000,
         max_global_series_per_metric: 30000,
 
-        max_series_per_query: 100000,
-
         ingestion_rate: 30000,
         ingestion_burst_size: 300000,
 
@@ -299,8 +294,6 @@
 
         max_global_series_per_user: 1000000,
         max_global_series_per_metric: 100000,
-
-        max_series_per_query: 100000,
 
         ingestion_rate: 100000,
         ingestion_burst_size: 1000000,
@@ -319,8 +312,6 @@
         max_global_series_per_user: 3000000,  // 3M
         max_global_series_per_metric: 300000,  // 300K
 
-        max_series_per_query: 100000,
-
         ingestion_rate: 350000,  // 350K
         ingestion_burst_size: 3500000,  // 3.5M
 
@@ -334,8 +325,6 @@
       big_user:: {
         max_series_per_metric: 0,  // Disabled in favour of the max global limit
         max_series_per_user: 0,  // Disabled in favour of the max global limit
-
-        max_series_per_query: 100000,
 
         max_global_series_per_user: 6000000,  // 6M
         max_global_series_per_metric: 600000,  // 600K
@@ -357,8 +346,6 @@
         max_global_series_per_user: 12000000,  // 12M
         max_global_series_per_metric: 1200000,  // 1.2M
 
-        max_series_per_query: 100000,
-
         ingestion_rate: 1500000,  // 1.5M
         ingestion_burst_size: 15000000,  // 15M
 
@@ -376,8 +363,6 @@
 
         max_global_series_per_user: 16000000,  // 16M
         max_global_series_per_metric: 1600000,  // 1.6M
-
-        max_series_per_query: 100000,
 
         ingestion_rate: 2250000,  // 2.25M
         ingestion_burst_size: 22500000,  // 22.5M


### PR DESCRIPTION
See issue: https://github.com/cortexproject/cortex-jsonnet/issues/61

**What this PR does**:
Remove [deprecated option `max_series_per_query`](https://github.com/cortexproject/cortex/blob/release-1.18/pkg/util/validation/limits.go#L216)

**Which issue(s) this PR fixes**:
Fixes #61 

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
